### PR TITLE
use 'default-features' = false on futures-util

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ license = "MIT"
 futures-channel = "0.3"
 futures-core = "0.3"
 futures-io = "0.3"
-futures-util = "0.3"
+futures-util = { version = "0.3", default-features = false }
 
 [dev-dependencies]
 criterion = "0.3"


### PR DESCRIPTION
this removes the unnecessary `syn` dependency