### PR TITLE
Fix panic caused by race condition when writing while dropping reader

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,7 +18,7 @@ jobs:
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: "1.39.0"
+          toolchain: "1.41.1"
           default: true
 
       - run: cargo test

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,7 +13,28 @@ jobs:
     env:
       RUST_BACKTRACE: 1
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v2
+
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          default: true
+
+      - run: cargo test
+
+  check:
+    strategy:
+      matrix:
+        platform:
+          - ubuntu-latest
+          - macos-latest
+          - windows-latest
+    runs-on: ${{ matrix.platform }}
+    env:
+      RUST_BACKTRACE: 1
+    steps:
+      - uses: actions/checkout@v2
 
       - uses: actions-rs/toolchain@v1
         with:
@@ -21,4 +42,4 @@ jobs:
           toolchain: "1.41.1"
           default: true
 
-      - run: cargo test
+      - run: cargo check

--- a/tests/pipe.rs
+++ b/tests/pipe.rs
@@ -90,7 +90,7 @@ fn pipe_lots_of_data() {
 }
 
 #[quickcheck]
-fn read_write_chunks_random(chunks: u16) {
+fn read_write_chunks_random(chunks: u8) {
     block_on(async {
         let data = [0; 8192];
         let (mut reader, mut writer) = pipe();


### PR DESCRIPTION
`Writer` has a race condition that might cause a panic if `poll_write` is called more than once while the `Reader` is in the processed of being dropped on another thread.

The race condition is caused by the drop order of `Reader`: Since fields are dropped in the order they are defined in, the buffer pool channel is dropped _before_ the buffer stream channel. If `poll_write` is called more than once between these two drop calls, then the underlying channel will panic because we've polled it after already returning `None`.

The fix is to ensure the buffer stream channel is closed _first_ before the buffer pool channel, since that is the channel we use to detect when the reader is closed. One way of doing this would be to just reverse the order these two fields are defined in, but it is better to be clear that the drop order matters by using an explicit drop handler.

With this fix, we know that the second channel will be polled _at most_ once when closed, because subsequent calls to `poll_write` will check the first channel before polling the second.

See also https://github.com/sagebind/isahc/issues/295.