### PR TITLE
Switch channel implementation to async-channel

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ categories = ["asynchronous", "concurrency", "data-structures"]
 license = "MIT"
 
 [dependencies]
-futures-channel = "0.3"
+async-channel = "1"
 futures-core = "0.3"
 futures-io = "0.3"
 


### PR DESCRIPTION
Switch the underlying channel implementation from futures-channel to async-channel, since the former has been shown to fall behind on performance metrics. In addition, crates from the futures project tend to have slower compile times compared to some alternatives.

Fixes #18.