### PR TITLE
chore: release v0.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,19 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.5.6](https://github.com/sagebind/sluice/compare/v0.5.5...v0.5.6) - 2025-06-20
+## [0.6.0](https://github.com/sagebind/sluice/compare/v0.5.5...v0.6.0) - 2025-06-20
+
+This version increases the MSRV from 1.66 to 1.74.
+
+### Dependencies
+
+- Bump criterion from 0.5.1 to 0.6.0 ([#26](https://github.com/sagebind/sluice/pull/26))
+- Bump quickcheck_macros from 1.0.0 to 1.1.0 ([#25](https://github.com/sagebind/sluice/pull/25))
+- Upgrade async-channel to v2 ([#23](https://github.com/sagebind/sluice/pull/23))
+- Update criterion requirement from 0.3 to 0.5 ([#21](https://github.com/sagebind/sluice/pull/21))
 
 ### Other
 
-- Bump criterion from 0.5.1 to 0.6.0 ([#26](https://github.com/sagebind/sluice/pull/26))
-- update release-plz configuration
-- Bump quickcheck_macros from 1.0.0 to 1.1.0 ([#25](https://github.com/sagebind/sluice/pull/25))
-- Test out release-plz
-- Upgrade async-channel to v2 ([#23](https://github.com/sagebind/sluice/pull/23))
+- Set up release-plz to automate new releases
 - Fix copypasta
 - Fix CI badge
-- Update criterion requirement from 0.3 to 0.5 ([#21](https://github.com/sagebind/sluice/pull/21))
 - Update edition and set MSRV to 1.66 ([#22](https://github.com/sagebind/sluice/pull/22))
-- Update sponsors list in README
-- Update sponsors on a schedule
-- Add sponsors to README

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,25 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.5.6](https://github.com/sagebind/sluice/compare/v0.5.5...v0.5.6) - 2025-06-20
+
+### Other
+
+- Bump criterion from 0.5.1 to 0.6.0 ([#26](https://github.com/sagebind/sluice/pull/26))
+- update release-plz configuration
+- Bump quickcheck_macros from 1.0.0 to 1.1.0 ([#25](https://github.com/sagebind/sluice/pull/25))
+- Test out release-plz
+- Upgrade async-channel to v2 ([#23](https://github.com/sagebind/sluice/pull/23))
+- Fix copypasta
+- Fix CI badge
+- Update criterion requirement from 0.3 to 0.5 ([#21](https://github.com/sagebind/sluice/pull/21))
+- Update edition and set MSRV to 1.66 ([#22](https://github.com/sagebind/sluice/pull/22))
+- Update sponsors list in README
+- Update sponsors on a schedule
+- Add sponsors to README

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -621,7 +621,7 @@ dependencies = [
 
 [[package]]
 name = "sluice"
-version = "0.5.5"
+version = "0.5.6"
 dependencies = [
  "async-channel",
  "criterion",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -621,7 +621,7 @@ dependencies = [
 
 [[package]]
 name = "sluice"
-version = "0.5.6"
+version = "0.6.0"
 dependencies = [
  "async-channel",
  "criterion",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sluice"
-version = "0.5.5"
+version = "0.5.6"
 authors = ["Stephen M. Coakley <me@stephencoakley.com>"]
 edition = "2021"
 description = "Efficient ring buffer for byte buffers, FIFO queues, and SPSC channels"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sluice"
-version = "0.5.6"
+version = "0.6.0"
 authors = ["Stephen M. Coakley <me@stephencoakley.com>"]
 edition = "2021"
 description = "Efficient ring buffer for byte buffers, FIFO queues, and SPSC channels"


### PR DESCRIPTION


## 🤖 New release

* `sluice`: 0.5.5 -> 0.6.0

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.5.6](https://github.com/sagebind/sluice/compare/v0.5.5...v0.5.6) - 2025-06-20

### Other

- Bump criterion from 0.5.1 to 0.6.0 ([#26](https://github.com/sagebind/sluice/pull/26))
- update release-plz configuration
- Bump quickcheck_macros from 1.0.0 to 1.1.0 ([#25](https://github.com/sagebind/sluice/pull/25))
- Test out release-plz
- Upgrade async-channel to v2 ([#23](https://github.com/sagebind/sluice/pull/23))
- Fix copypasta
- Fix CI badge
- Update criterion requirement from 0.3 to 0.5 ([#21](https://github.com/sagebind/sluice/pull/21))
- Update edition and set MSRV to 1.66 ([#22](https://github.com/sagebind/sluice/pull/22))
- Update sponsors list in README
- Update sponsors on a schedule
- Add sponsors to README
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).